### PR TITLE
Update to new API (V2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > This is a fork of [this repo](https://github.com/JannikArndt/arte-downloader), which currently uses the v1 api from arte, they recently switched to a new version that uses HLS Streams, which prompted me to make a few changes to the script.
 
 
-Since movies on Arte.tv are only available online for a _limited_ amount of time, you might want to download something before it's gone. This helps.
+Since movies on Arte.tv are only available online for a _limited_ amount of time, you might want to download something to watch later. Please remember to buy the original copies, for the artists and production.
 
 # How-To
 

--- a/README.md
+++ b/README.md
@@ -22,16 +22,3 @@ Paste the url of the video, select a quality, that's it.
 # Dependencies
 
 This script uses `curl`, `jq`, `sed` and `yt-dlp`.
-
-
-# How the V2 Arte API
-
-1. Get video ID from provided URL
-2. Get JSON for the video 
-3. Parse JSON for metadata, versions and title
-4. Use link in the json streams var to get m3u8 data
-5. Use the m3u8 data to get streams
-   1. The video
-   2. The audio
-   3. Subs which are linked in the main m3u8 file 
-6. Assemble the streams into full video !

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
-# Arte Downloader
+# Arte Downloader V2
 
-Since movies in German public television are only available online for a _limited_ amount of time, you might want to download something before it's gone. This helps.
+> This is a fork of [this repo](https://github.com/JannikArndt/arte-downloader), which currently uses the v1 api from arte, they recently switched to a new version that uses HLS Streams, which prompted me to make a few changes to the script.
+
+
+Since movies on Arte.tv are only available online for a _limited_ amount of time, you might want to download something before it's gone. This helps.
 
 # How-To
 
-Run the script from Terminal:
+1. Install [`yt-dlp`](https://github.com/yt-dlp/yt-dlp), an extended `youtube-dl` variant, using your preffered package manager.
+
+2. Run the script from Terminal:
 
 ```bash
 ./arte_downloader.sh
@@ -16,4 +21,17 @@ Paste the url of the video, select a quality, that's it.
 
 # Dependencies
 
-This script uses `curl`, `jq` and `sed`.
+This script uses `curl`, `jq`, `sed` and `yt-dlp`.
+
+
+# How the V2 Arte API
+
+1. Get video ID from provided URL
+2. Get JSON for the video 
+3. Parse JSON for metadata, versions and title
+4. Use link in the json streams var to get m3u8 data
+5. Use the m3u8 data to get streams
+   1. The video
+   2. The audio
+   3. Subs which are linked in the main m3u8 file 
+6. Assemble the streams into full video !

--- a/arte_downloader.sh
+++ b/arte_downloader.sh
@@ -23,7 +23,6 @@ FILES=$(echo $JSON | jq '.data.attributes.streams | map({version: .versions[0].l
 
 echo -e "\n${BRed}$TITLE${NC}"
 
-echo $FILES
 # Extract Qualities and URLS
 QUALITIES=$(echo $FILES | jq -r '.[] | ("\(.version) (Quality \(.quality))")' | nl -s ': ' )
 NUMBER_OF_QUALITIES=$(echo $FILES | jq length)
@@ -33,16 +32,9 @@ read -p "$(tput setaf 4)Choose quality (1-$NUMBER_OF_QUALITIES) $(tput sgr0)" CH
 
 SELECTED_FILE=$(echo $FILES | jq '.['$CHOSEN_QUALITY-1']')
 SELECTED_URL=$(echo $SELECTED_FILE | jq -r '.url')
-
-
-echo $SELECTED_URL
-echo $SELECTED_FILE
-
 SELECTED_VERSION=$(echo $SELECTED_FILE | jq -r '.version')
 CLEANED_NAME=$(echo "$TITLE ($SELECTED_VERSION)" | sed -e 's/[<>:"/\|?*]/_/g')
 
-yt-dlp "$SELECTED_URL" --all-subs -o "$CLEANED_NAME.%(ext)s" 
-
-
 # Download
+yt-dlp "$SELECTED_URL" --all-subs -o "$CLEANED_NAME.%(ext)s" 
 echo -e "${BRed}File saved in current directory, with available subtitles${NC}"

--- a/arte_downloader.sh
+++ b/arte_downloader.sh
@@ -10,31 +10,39 @@ URL="$1"
 [ -z "$URL" ] && read -p "$(tput setaf 4)Paste the URL here: $(tput sgr0)" URL
 
 # Extract shortcode from URL
-SHORTCODE=$(echo "$URL" | sed --regexp-extended 's/.*arte.tv\/.+\/videos\/([a-zA-Z0-9\-]+)\/.*/\1/')
+SHORTCODE=$(echo "$URL" | sed -E 's/.*arte.tv\/.+\/videos\/([a-zA-Z0-9\-]+)\/.*/\1/')
 echo "Shotcode: $SHORTCODE"
 echo "Downloading JSON from ARTE API…"
 
 # Download JSON with Video Data
-JSON=$(curl -s https://api.arte.tv/api/player/v1/config/de/$SHORTCODE)
+JSON=$(curl -s https://api.arte.tv/api/player/v2/config/fr/$SHORTCODE)
 
-TITLE=$(echo $JSON | jq -r '.videoJsonPlayer.VTI')
-FILES=$(echo $JSON | jq '.videoJsonPlayer.VSR | map({version: .versionLibelle, quality: .quality, width: .width, height: .height, mediaType: .mediaType, bitrate: .bitrate, url: .url})' )
+
+TITLE=$(echo $JSON | jq -r '.data.attributes.metadata.title')
+FILES=$(echo $JSON | jq '.data.attributes.streams | map({version: .versions[0].label, quality: .mainQuality.label, url: .url})' )
 
 echo -e "\n${BRed}$TITLE${NC}"
 
+echo $FILES
 # Extract Qualities and URLS
-QUALITIES=$(echo $FILES | jq -r '.[] | ("\(.version) (Quality \(.quality) \(.mediaType) \(.width) x \(.height) @ \(.bitrate)fps)")' | nl -s ': ' )
+QUALITIES=$(echo $FILES | jq -r '.[] | ("\(.version) (Quality \(.quality))")' | nl -s ': ' )
 NUMBER_OF_QUALITIES=$(echo $FILES | jq length)
+
 echo -e "Available qualities: \n$QUALITIES"
 read -p "$(tput setaf 4)Choose quality (1-$NUMBER_OF_QUALITIES) $(tput sgr0)" CHOSEN_QUALITY
 
 SELECTED_FILE=$(echo $FILES | jq '.['$CHOSEN_QUALITY-1']')
 SELECTED_URL=$(echo $SELECTED_FILE | jq -r '.url')
-SELECTED_FORMAT=$(echo $SELECTED_FILE | jq -r '.mediaType')
+
+
+echo $SELECTED_URL
+echo $SELECTED_FILE
+
 SELECTED_VERSION=$(echo $SELECTED_FILE | jq -r '.version')
 CLEANED_NAME=$(echo "$TITLE ($SELECTED_VERSION)" | sed -e 's/[<>:"/\|?*]/_/g')
-OUTPUT_FILE="$CLEANED_NAME.$SELECTED_FORMAT"
+
+yt-dlp "$SELECTED_URL" --all-subs -o "$CLEANED_NAME.%(ext)s" 
+
 
 # Download
-echo -e "${BRed}Saving file as $(pwd)/$OUTPUT_FILE...${NC}"
-curl -C - -L $SELECTED_URL -o "$OUTPUT_FILE" --progress-bar
+echo -e "${BRed}File saved in current directory, with available subtitles${NC}"


### PR DESCRIPTION
Hi, this is my first pull request so please let me know if there's anything I could improve :) 

I updated your repo to using the 2nd version of the API, and subsequently to use _yt-dlp_ to download the video, since the new API Arte uses is using a different format from previously, and it would be a lot of work to reimplement a lite, minimalistic version of what yt-dlp does (which requires ffmpeg anyway).

Also switched to using the french api, names are a bit more descriptive (at least to me).

Thanks !